### PR TITLE
Convert signatures to strings before hashing

### DIFF
--- a/lib/sign/HmacSigner.cfc
+++ b/lib/sign/HmacSigner.cfc
@@ -162,7 +162,7 @@ component
 		var expectedSignature = sign( message );
 
 		// Compare the two binary values using a quick hash.
-		return( hash( signature ) == hash( expectedSignature ) );
+		return( hash( toString( signature ) ) == hash( toString( expectedSignature ) ) );
 
 	}
 


### PR DESCRIPTION
Provides compatibility for CF9 by preventing error of "ByteArray objects cannot be converted to strings".